### PR TITLE
try to consolidate ecdsa recover flows

### DIFF
--- a/snapshots/MinimalDelegation4337Test.json
+++ b/snapshots/MinimalDelegation4337Test.json
@@ -1,4 +1,4 @@
 {
-  "hanldeOps_BATCHED_CALL_singleCall_P256": "201685",
-  "hanldeOps_BATCHED_CALL_singleCall_eoaSigner": "177500"
+  "hanldeOps_BATCHED_CALL_singleCall_P256": "201423",
+  "hanldeOps_BATCHED_CALL_singleCall_eoaSigner": "178350"
 }

--- a/snapshots/MinimalDelegationExecuteTest.json
+++ b/snapshots/MinimalDelegationExecuteTest.json
@@ -1,8 +1,8 @@
 {
-  "execute_BATCHED_CALL_opData_P256_singleCall": "92750",
-  "execute_BATCHED_CALL_opData_singleCall": "68581",
-  "execute_BATCHED_CALL_opData_singleCall_native": "69638",
-  "execute_BATCHED_CALL_opData_twoCalls": "105288",
+  "execute_BATCHED_CALL_opData_P256_singleCall": "92493",
+  "execute_BATCHED_CALL_opData_singleCall": "69440",
+  "execute_BATCHED_CALL_opData_singleCall_native": "70496",
+  "execute_BATCHED_CALL_opData_twoCalls": "106154",
   "execute_BATCHED_CALL_singleCall": "57631",
   "execute_BATCHED_CALL_singleCall_native": "58709",
   "execute_BATCHED_CALL_twoCalls": "92820",

--- a/snapshots/MinimalDelegationTest.json
+++ b/snapshots/MinimalDelegationTest.json
@@ -1,6 +1,6 @@
 {
-  "authorize": "210092",
+  "authorize": "210098",
   "revoke": "58203",
-  "validateUserOp_missingAccountFunds": "61739",
-  "validateUserOp_no_missingAccountFunds": "31120"
+  "validateUserOp_missingAccountFunds": "62589",
+  "validateUserOp_no_missingAccountFunds": "31970"
 }

--- a/src/libraries/CalldataDecoder.sol
+++ b/src/libraries/CalldataDecoder.sol
@@ -27,6 +27,16 @@ library CalldataDecoder {
         _data = data.toBytes(1);
     }
 
+    /// @notice equivalent to abi.decode(data, (bytes32, bytes)) in calldata
+    /// @return _value A bytes32 value
+    /// @return _data Bytes data following the bytes32 value.
+    function decodeBytes32Bytes(bytes calldata data) internal pure returns (bytes32 _value, bytes calldata _data) {
+        assembly {
+            _value := calldataload(data.offset)
+        }
+        _data = data.toBytes(1);
+    }
+
     // TODO length check
     function decodeCalls(bytes calldata data) internal pure returns (Call[] calldata calls) {
         assembly {

--- a/src/libraries/SignatureUnwrapper.sol
+++ b/src/libraries/SignatureUnwrapper.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {CalldataDecoder} from "./CalldataDecoder.sol";
+
+library SignatureUnwrapper {
+    using CalldataDecoder for bytes;
+
+    bytes32 public constant ROOT_KEY_HASH = bytes32(0);
+
+    /// @notice Unwraps a signature.
+    /// @dev If the signature length is 64 or 65, it is not wrapped and is returned to be verified against the root key.
+    function unwrap(bytes calldata _signature) internal pure returns (bytes32 keyHash, bytes calldata signature) {
+        if (_signature.length == 64 || _signature.length == 65) {
+            /// The signature is not wrapped, so it must be a signature derived from the root key.
+            return (ROOT_KEY_HASH, _signature);
+        } else {
+            (keyHash, signature) = _signature.decodeBytes32Bytes();
+        }
+    }
+}


### PR DESCRIPTION
I don't like how in the vanilla ECDSA signature case we are encoding and decoding the public key, and creating a Root Key object to operate on buttt I love that there is only one control flow to all ECDSA signature recovery

lmk if you have suggestions!

also not sure about doing all the recovery in calldata, its maybe around a 500 gas optimization from looking at snapshots