### PR TITLE
WIP: add notes for auditors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ a minimal, non-upgradeable implementation contract that can be set on an EIP-770
 ## Architecture
 - **Non-Upgradeability**: Upgradability is only allowed through re-delegation rather than a proxy.
 - **Singleton:** One canonical contract is delegated to.
+
+## Special areas of interest for audits
+- Ordering of `execute` calls within a multicall
+- TransientAllowance does not work with custom `layout` storage in solc 0.8.29. Can there ever be a collision?
+


### PR DESCRIPTION
to add:

- HookData can be set by a relaying party, it's not signed over by the authorizing key except when included in SignedCalls
- `ValidUntil` is not set if the signature is invalid for validateUserOp path per #115 