### PR TITLE
Fuzz settings in invariant tests

### DIFF
--- a/test/MinimalDelegation.execute.invariant.t.sol
+++ b/test/MinimalDelegation.execute.invariant.t.sol
@@ -64,8 +64,8 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
 
     /// @notice Sets the current key for the test
     /// if the test uses `caller`, we prank the key's public key
-    modifier useKey(uint256 keyIndexSeed) {
-        currentSigningKey = _seedKeyFromArray(signingKeys, keyIndexSeed);
+    modifier useKey() {
+        currentSigningKey = _randKeyFromArray(signingKeys);
         _;
     }
 
@@ -91,7 +91,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     /// TODO: only supports single call arrays for now
     /// - Generates a random call, executes it, then processes any registered callbacks
     /// - Any reverts are expected by the generated handler call
-    function executeBatchedCall(uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) setBlock() {
+    function executeBatchedCall(uint256 generatorSeed) public useKey() setBlock() {
         address caller = vm.addr(currentSigningKey.privateKey);
         vm.startPrank(caller);
         HandlerCall memory handlerCall = _generateHandlerCall(generatorSeed);
@@ -116,7 +116,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     /// @dev Handler function meant to be called during invariant tests
     /// TODO: only supports single call arrays for now
     /// - If the signing key is not registered on the account, expect the call to revert
-    function executeWithOpData(uint192 nonceKey, uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) setBlock() {
+    function executeWithOpData(uint192 nonceKey, uint256 generatorSeed) public useKey() setBlock() {
         bool isRootKey = vm.addr(currentSigningKey.privateKey) == address(signerAccount);
         bytes32 currentKeyHash = currentSigningKey.toKeyHash();
 

--- a/test/MinimalDelegation.execute.invariant.t.sol
+++ b/test/MinimalDelegation.execute.invariant.t.sol
@@ -23,6 +23,7 @@ import {Settings, SettingsLib} from "../src/libraries/SettingsLib.sol";
 import {SettingsBuilder} from "./utils/SettingsBuilder.sol";
 import {SignedCalls, SignedCallsLib} from "../src/libraries/SignedCallsLib.sol";
 import {InvariantRevertLib} from "./utils/InvariantRevertLib.sol";
+import {InvariantBlock} from "./utils/InvariantFixtures.sol";
 
 // To avoid stack to deep
 struct SetupParams {
@@ -55,6 +56,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     {
         for (uint256 i = 0; i < _params._signingKeys.length; i++) {
             signingKeys.push(_params._signingKeys[i]);
+            fixtureKeys.push(_params._signingKeys[i]);
         }
         tokenA = ERC20Mock(_params._tokenA);
         tokenB = ERC20Mock(_params._tokenB);
@@ -63,7 +65,18 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     /// @notice Sets the current key for the test
     /// if the test uses `caller`, we prank the key's public key
     modifier useKey(uint256 keyIndexSeed) {
-        (currentSigningKey,) = _rand(signingKeys, keyIndexSeed);
+        currentSigningKey = _seedKeyFromArray(signingKeys, keyIndexSeed);
+        _;
+    }
+
+    modifier setBlock() {
+        InvariantBlock memory _block = _randBlock();
+        if (_block.blockNumber != block.number) {
+            vm.roll(_block.blockNumber);
+        }
+        if (_block.blockTimestamp != block.timestamp) {
+            vm.warp(_block.blockTimestamp);
+        }
         _;
     }
 
@@ -78,7 +91,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     /// TODO: only supports single call arrays for now
     /// - Generates a random call, executes it, then processes any registered callbacks
     /// - Any reverts are expected by the generated handler call
-    function executeBatchedCall(uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) {
+    function executeBatchedCall(uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) setBlock() {
         address caller = vm.addr(currentSigningKey.privateKey);
         vm.startPrank(caller);
         HandlerCall memory handlerCall = _generateHandlerCall(generatorSeed);
@@ -103,7 +116,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
     /// @dev Handler function meant to be called during invariant tests
     /// TODO: only supports single call arrays for now
     /// - If the signing key is not registered on the account, expect the call to revert
-    function executeWithOpData(uint192 nonceKey, uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) {
+    function executeWithOpData(uint192 nonceKey, uint256 generatorSeed, uint256 signerSeed) public useKey(signerSeed) setBlock() {
         bool isRootKey = vm.addr(currentSigningKey.privateKey) == address(signerAccount);
         bytes32 currentKeyHash = currentSigningKey.toKeyHash();
 
@@ -127,12 +140,15 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
                 // Expect revert if expired
                 (bool isExpired,) = settings.isExpired();
                 if (isExpired) {
+                    _state.validationFailed_KeyExpired++;
                     expectedReverts = expectedReverts.push(abi.encodeWithSelector(IKeyManagement.KeyExpired.selector));
                 } else if (!settings.isAdmin() && calls.containsSelfCall()) {
+                    _state.validationFailed_OnlyAdminCanSelfCall++;
                     expectedReverts =
                         expectedReverts.push(abi.encodeWithSelector(IKeyManagement.OnlyAdminCanSelfCall.selector));
                 }
             } catch (bytes memory revertData) {
+                _state.validationFailed_KeyDoesNotExist++;
                 assertEq(bytes4(revertData), IKeyManagement.KeyDoesNotExist.selector);
                 expectedReverts = expectedReverts.push(abi.encodeWithSelector(IKeyManagement.KeyDoesNotExist.selector));
             }

--- a/test/utils/FunctionCallGenerator.sol
+++ b/test/utils/FunctionCallGenerator.sol
@@ -102,7 +102,7 @@ abstract contract FunctionCallGenerator is InvariantFixtures {
      * @return A call object for the generated function
      */
     function _generateHandlerCall(uint256 randomSeed) internal returns (HandlerCall memory) {
-        TestKey memory testKey = _seedKeyFromArray(fixtureKeys, randomSeed);
+        TestKey memory testKey = _randKeyFromArray(fixtureKeys);
         bytes32 keyHash = testKey.toKeyHash();
 
         bool isRegistered;
@@ -132,10 +132,10 @@ abstract contract FunctionCallGenerator is InvariantFixtures {
         // UPDATE == 2
         else if (randomSeed % FUZZED_FUNCTION_COUNT == 2) {
             Settings settings = _randSettings();
-            if (_testKeyIsSignerAccount(testKey)) {
-                revertData = _wrapCallFailedRevertData(IKeyManagement.CannotUpdateRootKey.selector);
-            } else if (!isRegistered) {
+            if (!isRegistered) {
                 revertData = _wrapCallFailedRevertData(IKeyManagement.KeyDoesNotExist.selector);
+            } else if (_testKeyIsSignerAccount(testKey)) {
+                revertData = _wrapCallFailedRevertData(IKeyManagement.CannotUpdateRootKey.selector);
             }
             return _updateCall(keyHash, settings, revertData);
         } else {

--- a/test/utils/FunctionCallGenerator.sol
+++ b/test/utils/FunctionCallGenerator.sol
@@ -41,7 +41,6 @@ abstract contract FunctionCallGenerator is Test, InvariantFixtures {
 
     // Keys that will be operated over in generated calldata
     TestKey[] public fixture_keys;
-    Settings[] public fixtureSettings;
 
     constructor(IMinimalDelegation _signerAccount, address tokenA, address tokenB) {
         signerAccount = _signerAccount;
@@ -52,9 +51,6 @@ abstract contract FunctionCallGenerator is Test, InvariantFixtures {
         for (uint256 i = 0; i < MAX_KEYS; i++) {
             fixture_keys.push(TestKeyManager.withSeed(KeyType.Secp256k1, vm.randomUint()));
         }
-
-        fixtureSettings.push(SettingsLib.DEFAULT);
-        fixtureSettings.push(SettingsBuilder.init().fromIsAdmin(true));
     }
 
     function _rand(TestKey[] storage keys, uint256 seed) internal view returns (TestKey memory, uint256) {
@@ -147,13 +143,14 @@ abstract contract FunctionCallGenerator is Test, InvariantFixtures {
         }
         // UPDATE == 2
         else if (randomSeed % FUZZED_FUNCTION_COUNT == 2) {
+            Settings settings = _randSettings(randomSeed);
+
             if (_testKeyIsSignerAccount(testKey)) {
                 revertData = _wrapCallFailedRevertData(IKeyManagement.CannotUpdateRootKey.selector);
             } else if (!isRegistered) {
                 revertData = _wrapCallFailedRevertData(IKeyManagement.KeyDoesNotExist.selector);
             }
-            // TODO: fuzz settings
-            return _updateCall(keyHash, Settings.wrap(0), revertData);
+            return _updateCall(keyHash, settings, revertData);
         } else {
             return _tokenTransferCall(_tokenA, vm.randomAddress(), 1);
         }

--- a/test/utils/InvariantFixtures.sol
+++ b/test/utils/InvariantFixtures.sol
@@ -63,9 +63,6 @@ abstract contract InvariantFixtures is Test {
         fixtureSettings.push(SettingsBuilder.init());
         fixtureSettings.push(SettingsBuilder.init().fromIsAdmin(true));
         fixtureSettings.push(SettingsBuilder.init().fromExpiration(uint40(expirationTime)));
-        for (uint256 i = 0; i < fixtureSettings.length; i++) {
-            console2.log("fixtureSettings[%s] %s", i, Settings.unwrap(fixtureSettings[i]));
-        }
 
         // Add the current block
         fixtureBlocks.push(InvariantBlock({blockNumber: block.number, blockTimestamp: block.timestamp}));
@@ -73,8 +70,8 @@ abstract contract InvariantFixtures is Test {
         fixtureBlocks.push(InvariantBlock({blockNumber: block.number + 1, blockTimestamp: expirationTime - 1}));
     }
 
-    function _seedKeyFromArray(TestKey[] storage _keys, uint256 randomSeed) internal view returns (TestKey memory) {
-        return _keys[randomSeed % _keys.length];
+    function _randKeyFromArray(TestKey[] storage _keys) internal returns (TestKey memory) {
+        return _keys[vm.randomUint() % _keys.length];
     }
 
     function _randSettings() internal returns (Settings) {

--- a/test/utils/InvariantFixtures.sol
+++ b/test/utils/InvariantFixtures.sol
@@ -7,8 +7,9 @@ import {Key, KeyLib} from "../../src/libraries/KeyLib.sol";
 import {TestKey, TestKeyManager} from "./TestKeyManager.sol";
 import {Call} from "../../src/libraries/CallLib.sol";
 import {Settings, SettingsLib} from "../../src/libraries/SettingsLib.sol";
+import {SettingsBuilder} from "./SettingsBuilder.sol";
 
-interface IInvariantStateTracker {
+interface IInvariantCallbacks {
     function registerCallback(Key calldata) external;
     function revokeCallback(bytes32) external;
     function updateCallback(bytes32, Settings) external;
@@ -28,8 +29,11 @@ struct InvariantState {
 
 /// Base contract for mirroring the state of signerAccount
 /// Internal state must only be updated by callbacks, which are triggered sequentially in order of Call[] after each top level call to execute
-abstract contract InvariantStateTracker {
+abstract contract InvariantFixtures {
+    using SettingsBuilder for Settings;
+
     InvariantState internal _state;
+    Settings[] internal fixtureSettings;
 
     function logState() public view {
         console2.log("[register] success %s", _state.registerSuccess);

--- a/test/utils/InvariantFixtures.sol
+++ b/test/utils/InvariantFixtures.sol
@@ -35,6 +35,19 @@ abstract contract InvariantFixtures {
     InvariantState internal _state;
     Settings[] internal fixtureSettings;
 
+    // Warp to this time for keys with expiration to expire
+    uint256 constant EXPIRATION_TIME = 100;
+
+    constructor() {
+        fixtureSettings.push(SettingsBuilder.init());
+        fixtureSettings.push(SettingsBuilder.init().fromIsAdmin(true));
+        fixtureSettings.push(SettingsBuilder.init().fromExpiration(uint40(EXPIRATION_TIME - 1)));
+    }
+
+    function _randSettings(uint256 randomSeed) internal view returns (Settings) {
+        return fixtureSettings[randomSeed % fixtureSettings.length];
+    }
+
     function logState() public view {
         console2.log("[register] success %s", _state.registerSuccess);
         console2.log("[register] reverted %s", _state.registerReverted);

--- a/test/utils/InvariantFixtures.sol
+++ b/test/utils/InvariantFixtures.sol
@@ -2,12 +2,14 @@
 pragma solidity ^0.8.29;
 
 import {console2} from "forge-std/console2.sol";
+import {Test} from "forge-std/Test.sol";
 import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 import {Key, KeyLib} from "../../src/libraries/KeyLib.sol";
 import {TestKey, TestKeyManager} from "./TestKeyManager.sol";
 import {Call} from "../../src/libraries/CallLib.sol";
 import {Settings, SettingsLib} from "../../src/libraries/SettingsLib.sol";
 import {SettingsBuilder} from "./SettingsBuilder.sol";
+import {KeyType} from "../../src/libraries/KeyLib.sol";
 
 interface IInvariantCallbacks {
     function registerCallback(Key calldata) external;
@@ -25,27 +27,62 @@ struct InvariantState {
     uint256 updateReverted;
     uint256 executeSuccess;
     uint256 executeReverted;
+
+    uint256 validationFailed_KeyExpired;
+    uint256 validationFailed_KeyDoesNotExist;
+    uint256 validationFailed_OnlyAdminCanSelfCall;
+}
+
+struct InvariantBlock {
+    uint256 blockNumber;
+    uint256 blockTimestamp;
 }
 
 /// Base contract for mirroring the state of signerAccount
 /// Internal state must only be updated by callbacks, which are triggered sequentially in order of Call[] after each top level call to execute
-abstract contract InvariantFixtures {
+abstract contract InvariantFixtures is Test {
     using SettingsBuilder for Settings;
+    using TestKeyManager for TestKey;
+
+    uint256 public constant MAX_KEYS = 10;
+
+    // Keys that will be operated over in generated calldata
+    TestKey[] internal fixtureKeys;
+    Settings[] internal fixtureSettings;
+    InvariantBlock[] internal fixtureBlocks;
 
     InvariantState internal _state;
-    Settings[] internal fixtureSettings;
-
-    // Warp to this time for keys with expiration to expire
-    uint256 constant EXPIRATION_TIME = 100;
 
     constructor() {
+        // Generate MAX_KEYS and add to fixtureKey
+        for (uint256 i = 0; i < MAX_KEYS; i++) {
+            fixtureKeys.push(TestKeyManager.withSeed(KeyType.Secp256k1, vm.randomUint()));
+        }
+
+        uint256 expirationTime = block.timestamp + 100;
         fixtureSettings.push(SettingsBuilder.init());
         fixtureSettings.push(SettingsBuilder.init().fromIsAdmin(true));
-        fixtureSettings.push(SettingsBuilder.init().fromExpiration(uint40(EXPIRATION_TIME - 1)));
+        fixtureSettings.push(SettingsBuilder.init().fromExpiration(uint40(expirationTime)));
+        for (uint256 i = 0; i < fixtureSettings.length; i++) {
+            console2.log("fixtureSettings[%s] %s", i, Settings.unwrap(fixtureSettings[i]));
+        }
+
+        // Add the current block
+        fixtureBlocks.push(InvariantBlock({blockNumber: block.number, blockTimestamp: block.timestamp}));
+        // Add a block which will be used for testing expiration
+        fixtureBlocks.push(InvariantBlock({blockNumber: block.number + 1, blockTimestamp: expirationTime - 1}));
     }
 
-    function _randSettings(uint256 randomSeed) internal view returns (Settings) {
-        return fixtureSettings[randomSeed % fixtureSettings.length];
+    function _seedKeyFromArray(TestKey[] storage _keys, uint256 randomSeed) internal view returns (TestKey memory) {
+        return _keys[randomSeed % _keys.length];
+    }
+
+    function _randSettings() internal returns (Settings) {
+        return fixtureSettings[vm.randomUint() % fixtureSettings.length];
+    }
+
+    function _randBlock() internal returns (InvariantBlock memory) {
+        return fixtureBlocks[vm.randomUint() % fixtureBlocks.length];
     }
 
     function logState() public view {
@@ -57,6 +94,10 @@ abstract contract InvariantFixtures {
         console2.log("[update] reverted %s", _state.updateReverted);
         console2.log("[execute] success %s", _state.executeSuccess);
         console2.log("[execute] reverted %s", _state.executeReverted);
+
+        console2.log("[validationFailed] keyExpired %s", _state.validationFailed_KeyExpired);
+        console2.log("[validationFailed] keyDoesNotExist %s", _state.validationFailed_KeyDoesNotExist);
+        console2.log("[validationFailed] onlyAdminCanSelfCall %s", _state.validationFailed_OnlyAdminCanSelfCall);
     }
 
     function registerCallback(Key memory key) external {


### PR DESCRIPTION
```
  Number of persisted registered keys
  9
  [register] success 88
  [register] reverted 14
  [revoke] success 36
  [revoke] reverted 99
  [update] success 34
  [update] reverted 78
  [execute] success 0
  [execute] reverted 0
  [validationFailed] keyExpired 0
  [validationFailed] keyDoesNotExist 28
  [validationFailed] onlyAdminCanSelfCall 95
```