### PR TITLE
chore: rename `shouldRevert` to `revertOnFailure`

### DIFF
--- a/snapshots/MinimalDelegationExecuteTest.json
+++ b/snapshots/MinimalDelegationExecuteTest.json
@@ -1,14 +1,14 @@
 {
   "execute_BATCHED_CALL_SUPPORTS_OPDATA_singleCall": "92999",
-  "execute_BATCHED_CALL_SUPPORTS_OPDATA_twoCalls": "129617",
+  "execute_BATCHED_CALL_SUPPORTS_OPDATA_twoCalls": "129605",
   "execute_BATCHED_CALL_opData_P256_singleCall": "118312",
   "execute_BATCHED_CALL_opData_singleCall": "92999",
   "execute_BATCHED_CALL_opData_singleCall_native": "93817",
-  "execute_BATCHED_CALL_opData_twoCalls": "129617",
+  "execute_BATCHED_CALL_opData_twoCalls": "129605",
   "execute_BATCHED_CALL_singleCall": "59631",
   "execute_BATCHED_CALL_singleCall_native": "59710",
   "execute_BATCHED_CALL_twoCalls": "95434",
   "execute_invalidMode_reverts": "23019",
-  "execute_signedBatchedCallL_executor_singleCall": "93251",
-  "multicall": "178587"
+  "execute_signedBatchedCallL_executor_singleCall": "93263",
+  "multicall": "178599"
 }

--- a/src/MinimalDelegation.sol
+++ b/src/MinimalDelegation.sol
@@ -75,7 +75,7 @@ contract MinimalDelegation is
     function execute(bytes32 mode, bytes memory executionData) external payable override {
         if (!mode.isBatchedCall()) revert IERC7821.UnsupportedExecutionMode();
         Call[] memory calls = abi.decode(executionData, (Call[]));
-        BatchedCall memory batchedCall = BatchedCall({calls: calls, shouldRevert: mode.shouldRevert()});
+        BatchedCall memory batchedCall = BatchedCall({calls: calls, revertOnFailure: mode.revertOnFailure()});
         execute(batchedCall);
     }
 
@@ -99,7 +99,7 @@ contract MinimalDelegation is
         for (uint256 i = 0; i < batchedCall.calls.length; i++) {
             (bool success, bytes memory output) = _execute(batchedCall.calls[i], keyHash);
             // Reverts with the first call that is unsuccessful if the EXEC_TYPE is set to force a revert.
-            if (!success && batchedCall.shouldRevert) revert IMinimalDelegation.CallFailed(output);
+            if (!success && batchedCall.revertOnFailure) revert IMinimalDelegation.CallFailed(output);
         }
     }
 

--- a/src/libraries/BatchedCallLib.sol
+++ b/src/libraries/BatchedCallLib.sol
@@ -5,7 +5,7 @@ import {Call, CallLib} from "./CallLib.sol";
 
 struct BatchedCall {
     Call[] calls;
-    bool shouldRevert;
+    bool revertOnFailure;
 }
 
 /// @title BatchedCallLib
@@ -15,11 +15,11 @@ library BatchedCallLib {
 
     /// @dev The type string for the BatchedCall struct
     bytes internal constant BATCHED_CALL_TYPE =
-        "BatchedCall(Call[] calls,bool shouldRevert)Call(address to,uint256 value,bytes data)";
+        "BatchedCall(Call[] calls,bool revertOnFailure)Call(address to,uint256 value,bytes data)";
     /// @dev The typehash for the BatchedCall struct
     bytes32 internal constant BATCHED_CALL_TYPEHASH = keccak256(BATCHED_CALL_TYPE);
 
     function hash(BatchedCall memory batchedCall) internal pure returns (bytes32) {
-        return keccak256(abi.encode(BATCHED_CALL_TYPEHASH, batchedCall.calls.hash(), batchedCall.shouldRevert));
+        return keccak256(abi.encode(BATCHED_CALL_TYPEHASH, batchedCall.calls.hash(), batchedCall.revertOnFailure));
     }
 }

--- a/src/libraries/ModeDecoder.sol
+++ b/src/libraries/ModeDecoder.sol
@@ -27,7 +27,7 @@ library ModeDecoder {
 
     // Revert if the EXEC_TYPE is 0.
     // The EXEC_TYPE is guaranteed to be ONLY 1 or 0 since the mode is checked with strict equality in isBatchedCall().
-    function shouldRevert(bytes32 mode) internal pure returns (bool) {
+    function revertOnFailure(bytes32 mode) internal pure returns (bool) {
         return mode & EXTRACT_EXEC_TYPE == 0;
     }
 }

--- a/src/libraries/SignedBatchedCallLib.sol
+++ b/src/libraries/SignedBatchedCallLib.sol
@@ -17,7 +17,7 @@ library SignedBatchedCallLib {
 
     /// @dev The type string for the SignedBatchedCall struct
     bytes internal constant SIGNED_BATCHED_CALL_TYPE =
-        "SignedBatchedCall(BatchedCall batchedCall,uint256 nonce,bytes32 keyHash,address executor)BatchedCall(Call[] calls,bool shouldRevert)Call(address to,uint256 value,bytes data)";
+        "SignedBatchedCall(BatchedCall batchedCall,uint256 nonce,bytes32 keyHash,address executor)BatchedCall(Call[] calls,bool revertOnFailure)Call(address to,uint256 value,bytes data)";
     /// @dev The typehash for the SignedBatchedCall struct
     bytes32 internal constant SIGNED_BATCHED_CALL_TYPEHASH = keccak256(SIGNED_BATCHED_CALL_TYPE);
 

--- a/test/MinimalDelegation.execute.invariant.t.sol
+++ b/test/MinimalDelegation.execute.invariant.t.sol
@@ -140,7 +140,7 @@ contract MinimalDelegationExecuteInvariantHandler is ExecuteFixtures, FunctionCa
         (uint256 nonce,) = _buildNextValidNonce(nonceKey);
         Call[] memory calls = handlerCalls.toCalls();
 
-        // TODO: remove the hardcoded shouldRevert once we can test for it
+        // TODO: remove the hardcoded revertOnFailure once we can test for it
         BatchedCall memory batchedCall = CallUtils.initBatchedCall().withCalls(calls).withShouldRevert(true);
         SignedBatchedCall memory signedBatchedCall =
             CallUtils.initSignedBatchedCall().withBatchedCall(batchedCall).withKeyHash(currentKeyHash).withNonce(nonce);

--- a/test/js-scripts/dist/sign-typed-data.js
+++ b/test/js-scripts/dist/sign-typed-data.js
@@ -8952,7 +8952,7 @@ var types = {
   ],
   BatchedCall: [
     { name: "calls", type: "Call[]" },
-    { name: "shouldRevert", type: "bool" }
+    { name: "revertOnFailure", type: "bool" }
   ],
   Call: [
     { name: "to", type: "address" },

--- a/test/js-scripts/src/utils/constants.ts
+++ b/test/js-scripts/src/utils/constants.ts
@@ -15,7 +15,7 @@ export const types = {
   ],
   BatchedCall: [
     { name: 'calls', type: 'Call[]' },
-    { name: 'shouldRevert', type: 'bool' }
+    { name: 'revertOnFailure', type: 'bool' }
   ],
   Call: [
     { name: 'to', type: 'address' },
@@ -33,7 +33,7 @@ export type Call = {
 
 export type BatchedCall = {
     calls: Call[];
-    shouldRevert: boolean;
+    revertOnFailure: boolean;
   }
 
 export interface SignedBatchedCall {

--- a/test/libraries/SignedBatchedCallLib.t.sol
+++ b/test/libraries/SignedBatchedCallLib.t.sol
@@ -16,16 +16,16 @@ contract SignedBatchedCallLibTest is Test {
     /// @notice Test to catch accidental changes to the typehash
     function test_constant_execution_data_typehash() public pure {
         bytes32 expectedTypeHash = keccak256(
-            "SignedBatchedCall(BatchedCall batchedCall,uint256 nonce,bytes32 keyHash,address executor)BatchedCall(Call[] calls,bool shouldRevert)Call(address to,uint256 value,bytes data)"
+            "SignedBatchedCall(BatchedCall batchedCall,uint256 nonce,bytes32 keyHash,address executor)BatchedCall(Call[] calls,bool revertOnFailure)Call(address to,uint256 value,bytes data)"
         );
         assertEq(SignedBatchedCallLib.SIGNED_BATCHED_CALL_TYPEHASH, expectedTypeHash);
     }
 
-    function test_hash_with_nonce_fuzz(Call[] memory calls, uint256 nonce, bytes32 keyHash, bool shouldRevert)
+    function test_hash_with_nonce_fuzz(Call[] memory calls, uint256 nonce, bytes32 keyHash, bool revertOnFailure)
         public
         pure
     {
-        BatchedCall memory batchedCall = CallUtils.initBatchedCall().withCalls(calls).withShouldRevert(shouldRevert);
+        BatchedCall memory batchedCall = CallUtils.initBatchedCall().withCalls(calls).withShouldRevert(revertOnFailure);
         SignedBatchedCall memory signedBatchedCall =
             CallUtils.initSignedBatchedCall().withBatchedCall(batchedCall).withNonce(nonce).withKeyHash(keyHash);
         bytes32 actualHash = signedBatchedCall.hash();

--- a/test/utils/CallUtils.sol
+++ b/test/utils/CallUtils.sol
@@ -102,7 +102,7 @@ library CallUtils {
     // BatchedCall operations
 
     function initBatchedCall() internal pure returns (BatchedCall memory) {
-        return BatchedCall({calls: new Call[](0), shouldRevert: false});
+        return BatchedCall({calls: new Call[](0), revertOnFailure: false});
     }
 
     function withCalls(BatchedCall memory batchedCall, Call[] memory calls)
@@ -114,12 +114,12 @@ library CallUtils {
         return batchedCall;
     }
 
-    function withShouldRevert(BatchedCall memory batchedCall, bool shouldRevert)
+    function withShouldRevert(BatchedCall memory batchedCall, bool revertOnFailure)
         internal
         pure
         returns (BatchedCall memory)
     {
-        batchedCall.shouldRevert = shouldRevert;
+        batchedCall.revertOnFailure = revertOnFailure;
         return batchedCall;
     }
 

--- a/test/utils/FFISignTypedData.sol
+++ b/test/utils/FFISignTypedData.sol
@@ -59,8 +59,8 @@ contract FFISignTypedData is JavascriptFfi {
             '"calls":',
             callsJson,
             ",",
-            '"shouldRevert":',
-            signedBatchedCall.batchedCall.shouldRevert ? "true" : "false",
+            '"revertOnFailure":',
+            signedBatchedCall.batchedCall.revertOnFailure ? "true" : "false",
             "}"
         );
 


### PR DESCRIPTION
fix #151 