### PR TITLE
:hammer: fix: make nonceSequenceNumber private

### DIFF
--- a/src/NonceManager.sol
+++ b/src/NonceManager.sol
@@ -7,7 +7,7 @@ import {BaseAuthorization} from "./BaseAuthorization.sol";
 /// @title NonceManager
 /// @notice A contract that manages nonces to prevent replay attacks
 abstract contract NonceManager is INonceManager, BaseAuthorization {
-    mapping(uint256 key => uint256 seq) public nonceSequenceNumber;
+    mapping(uint256 key => uint256 seq) private nonceSequenceNumber;
 
     /// @inheritdoc INonceManager
     function invalidateNonce(uint256 newNonce) external onlyThis {


### PR DESCRIPTION
The getter generated by this public variable appears to be redundant since we already have the `getSeq` getter. Neither is present in the [INonceManager.sol](https://github.com/Uniswap/calibur/blob/main/src/interfaces/INonceManager.sol) interface.

Should we make it private or is there a specific reason for keeping both getters?